### PR TITLE
Potential fix for code scanning alert no. 32: Server-side request forgery

### DIFF
--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -2684,6 +2684,10 @@ public class Configuration implements Iterable<Map.Entry<String, String>>, Writa
             return null;
         }
 
+        if (!isValidUrl(url)) {
+            throw new IOException("Invalid URL: " + url);
+        }
+
         URLConnection connection = url.openConnection();
         if (connection instanceof JarURLConnection) {
             // Disable caching for JarURLConnection to avoid sharing JarFile
@@ -2712,6 +2716,11 @@ public class Configuration implements Iterable<Map.Entry<String, String>>, Writa
                 StreamBootstrapper.getInstance(null, systemId, is),
                 false,
                 true);
+    }
+
+    private boolean isValidUrl(URL url) {
+        String allowedHost = "trusted.host.com"; // Replace with the actual allowed host
+        return allowedHost.equals(url.getHost());
     }
 
     private void loadResources(


### PR DESCRIPTION
Potential fix for [https://github.com/GeekMasherOrg/flink/security/code-scanning/32](https://github.com/GeekMasherOrg/flink/security/code-scanning/32) from the [SSRF](https://github.com/orgs/GeekMasherOrg/security/campaigns/3) security campaign.

To fix the SSRF vulnerability, we need to validate the `url` parameter before using it to open a connection. One way to do this is to maintain a list of allowed URLs or domains and ensure that the provided URL matches one of the allowed entries. Alternatively, we can restrict the URL to a specific host or URL prefix.

In this case, we will implement a validation method that checks if the URL's host matches a predefined allowed host. This method will be called before opening the connection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
